### PR TITLE
Fix native libs install

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -39,9 +39,9 @@ CC=@CC@
 @DEFAULT_COMPILER@=1
 
 # We have to use _build because of OCaml's bug #0004502
-OBJDIR      = _build
-BINDIR		  = bin
-CILLYDIR	  = lib/perl5
+OBJDIR    = _build
+BINDIR    = bin
+CILLYDIR  = lib/perl5
 
 # Ocaml tools
 OCAMLC = @OCAMLC@
@@ -86,9 +86,9 @@ CILLY_EXE_BIN = $(patsubst $(OBJDIR)/src/main.%,bin/$(CILLY).%,$(CILLY_EXE_FILES
 override OCAMLBUILD += -build-dir $(OBJDIR) -use-ocamlfind -no-links -classic-display
 
 OCAMLBUILD_TARGETS = \
-	$(CILLIB_TARGETS) \
-	$(CILLIB_FILES)		\
-  $(CILLY_EXE_FILES) \
+	$(CILLIB_TARGETS)  \
+	$(CILLIB_FILES)	   \
+	$(CILLY_EXE_FILES) \
 	$(CILDOC_INDEX)
 
 # Trick: this no-op rule is executed for each target, but
@@ -126,7 +126,7 @@ META:
 	  printf "archive(native) = \"$(plugin).cmxa\"\n" >> $@;\
 	  printf "archive(native,plugin) = \"$(plugin).cmxs\"\n" >> $@;\
 	  printf ")\n\n" >> $@;\
-		)
+	)
 
 # cilly perl wrapper
 prefix = @prefix@
@@ -188,7 +188,7 @@ $(OBJDIR)/machdep.ml : src/machdep-ml.c configure.ac Makefile.in
 	@echo "  little_endian: bool; (* whether the machine is little endian *)">>$@
 	@echo "  __thread_is_keyword: bool; (* whether __thread is a keyword *)">>$@
 	@echo "  __builtin_va_list: bool; (* whether __builtin_va_list is builtin (gccism) *)">>$@
-	@echo "}" >> $@ 	
+	@echo "}" >> $@
 	@if $(CC) -D_GNUCC $< -o $(OBJDIR)/machdep-ml.exe ;then \
 	    echo "machdep-ml.exe created succesfully." \
 	;else \

--- a/Makefile.in
+++ b/Makefile.in
@@ -73,6 +73,7 @@ ifeq ($(OCAMLNATDYNLINK),yes)
   CILLIB_TARGETS  += $(OBJDIR)/src/cil.cmxa $(OBJDIR)/src/cil.a
   CILLIB_TARGETS  += $(addsuffix .cmxa,$(CIL_PLUGINS))
   CILLIB_TARGETS  += $(addsuffix .cmxs,$(CIL_PLUGINS))
+  CILLIB_TARGETS  += $(addsuffix .a,$(CIL_PLUGINS))
   CILLY_EXE_FILES += $(OBJDIR)/src/main.native
 endif
 endif

--- a/configure
+++ b/configure
@@ -7395,4 +7395,5 @@ CIL configuration:
   gcc to use                  CC                 $CC
   default compiler            DEFAULT_COMPILER   $DEFAULT_COMPILER
   CIL version                 CIL_VERSION        $CIL_VERSION
+  Native OCaml CIL libs                          $OCAMLNATDYNLINK
 EOF

--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ DEFAULT_CIL_MODE=GNUCC
 # sometimes people have Common Lisp's interpreter called 'cl' ..
 AC_MSG_CHECKING(for msvc cl.exe (optional))
 # See if CC points to the MS compiler
-if "$CC" 2>&1 | grep "Microsoft" >/dev/null; then 
+if "$CC" 2>&1 | grep "Microsoft" >/dev/null; then
   AC_MSG_RESULT([found, set as default])
   HAS_MSVC=yes
   DEFAULT_COMPILER=_MSVC

--- a/configure.ac
+++ b/configure.ac
@@ -203,4 +203,5 @@ CIL configuration:
   gcc to use                  CC                 $CC
   default compiler            DEFAULT_COMPILER   $DEFAULT_COMPILER
   CIL version                 CIL_VERSION        $CIL_VERSION
+  Native OCaml CIL libs                          $OCAMLNATDYNLINK
 EOF

--- a/src/cfg.mli
+++ b/src/cfg.mli
@@ -4,9 +4,6 @@
   This is required for several other extensions, such as {!Dataflow}. 
 *)
 
-open Cil
-
-
 (** Compute the CFG for an entire file, by calling cfgFun on each function. *)
 val computeFileCFG: Cil.file -> unit
 
@@ -15,19 +12,19 @@ val clearFileCFG: Cil.file -> unit
 
 (** Compute a control flow graph for fd.  Stmts in fd have preds and succs
   filled in *)
-val cfgFun : fundec -> int
+val cfgFun : Cil.fundec -> int
 
 (** clear the sid, succs, and preds fields of each statment in a function *)
 val clearCFGinfo: Cil.fundec -> unit
 
 (** print control flow graph (in dot form) for fundec to channel *)
-val printCfgChannel : out_channel -> fundec -> unit
+val printCfgChannel : out_channel -> Cil.fundec -> unit
 
 (** Print control flow graph (in dot form) for fundec to file *)
-val printCfgFilename : string -> fundec -> unit
+val printCfgFilename : string -> Cil.fundec -> unit
 
 (** Next statement id that will be assigned. *)
 val start_id: int ref
 
 (** Return all statements in a file - valid after computeFileCfg only *)
-val allStmts : file -> stmt list
+val allStmts : Cil.file -> Cil.stmt list


### PR DESCRIPTION
Native OCaml CIL libs were not getting installed.  Configure will now log whether it will install native libs, and the Makefile was fixed to ensure their installation.  Also bundled some minor whitespace fixes, and a stylistic fix in cfg.mli.
