### PR TITLE
Extract out perl package App::Cilly::CilCompiler from cilly driver into ...

### DIFF
--- a/bin/cilly
+++ b/bin/cilly
@@ -44,8 +44,8 @@ use lib "$FindBin::RealBin/../lib/perl5";
 
 # Read the configuration script
 use App::Cilly::CilConfig;
-
 use App::Cilly;
+use App::Cilly::CilCompiler;
 
 $::default_is_merge = 0;
 my $stub = App::Cilly::CilCompiler->new(@ARGV);
@@ -54,116 +54,5 @@ $stub->setVersion ();
 
 # print Dumper($stub);
 $stub->doit();
-
-
-# Define here your favorite compiler by overriding Merger methods
-package App::Cilly::CilCompiler;
-use File::Basename;
-use strict;
-BEGIN {
-    @App::Cilly::CilCompiler::ISA = qw(App::Cilly);
-    $App::Cilly::CilCompiler::base =
-      "$FindBin::RealBin/$FindBin::RealScript";
-    # Use the most recent version of cilly
-    $App::Cilly::CilCompiler::mtime_native =
-    int((stat("$App::Cilly::CilCompiler::base.native"))[9]);
-    $App::Cilly::CilCompiler::mtime_byte =
-    int((stat("$App::Cilly::CilCompiler::base.byte"))[9]);
-    $App::Cilly::CilCompiler::use_debug = 
-         grep(/--bytecode/, @ARGV) ||
-         grep(/--ocamldebug/, @ARGV) ||
-        ($App::Cilly::CilCompiler::mtime_native < $App::Cilly::CilCompiler::mtime_byte);
-    $App::Cilly::CilCompiler::compiler = 
-        $App::Cilly::CilCompiler::base . 
-            ($App::Cilly::CilCompiler::use_debug ? ".byte" : ".native");
-    if($App::Cilly::CilCompiler::use_debug) { 
-        $ENV{"OCAMLRUNPARAM"} = "b" . $ENV{"OCAMLRUNPARAM"};
-    } 
-    # Fix ocamlfind search path
-    if(open (my $input_fh, "<",
-        "$FindBin::RealBin/../share/cil/ocamlpath")) {
-      my $ocamlpath = <$input_fh>;
-      chomp($ocamlpath);
-      close $input_fh;
-      # ocamlpath separator is ':' on Unix, but ';' on Windows
-      my $ocamlsep = ($^O eq "MSWin32" || $^O eq "cygwin") ? ';' : ':';
-      $ENV{"OCAMLPATH"} = join($ocamlsep, $ocamlpath, $ENV{"OCAMLPATH"});
-    }
-}
-
-# We need to customize the collection of arguments
-sub collectOneArgument {
-    my($self, $arg, $pargs) = @_;
-    if($arg =~ m|--transval=(.+)$|)  {
-        $self->{TRANSVAL} = $1; return 1;
-    }
-    if($arg eq '--ocamldebug')  {
-        $self->{OCAMLDEBUG} = 1; return 1;
-    }
-    if($arg eq '--cabsonly') {
-        $self->{CABSONLY} = 1; return 1;
-    }
-    # See if the super class understands this
-    return $self->SUPER::collectOneArgument($arg, $pargs);
-}
-
-sub usage {
-    print "Usage: $FindBin::Script [options] [gcc_or_mscl arguments]\n";
-}
-
-sub helpMessage {
-    my($self) = @_;
-    # Print first the original
-    $self->SUPER::helpMessage();
-    print <<EOF;
-
-  All other arguments starting with -- are passed to the Cilly process.
-
-The following are the arguments of the Cilly process
-EOF
-   my @cmd = ($App::Cilly::CilCompiler::compiler, '--help');
-   if(defined $stub->{CILARGS}) {
-       push @cmd, @{$stub->{CILARGS}};
-   }
-   $self->runShell(@cmd); 
-}
-
-
-sub CillyCommand {
-    my ($self, $ppsrc, $dest) = @_;
-
-    my $aftercil;
-    my @cmd = ($App::Cilly::CilCompiler::compiler);
-
-    if(defined $ENV{OCAMLDEBUG} || $self->{OCAMLDEBUG}) {
-        print "OCAMLDEBUG is on\n";
-        my @idirs = (".", "src", "src/frontc", "src/ext",
-                     "ocamlutil", 
-                     "obj/");
-	my @iflags = map { ('-I', "$FindBin::RealBin/../$_") } @idirs;
-        unshift @cmd, 'ocamldebug', '-emacs', @iflags;
-    }
-    if($::docxx) {
-        push @cmd, '--cxx';
-    }
-    if($self->{CABSONLY}) {
-        $aftercil = $self->cilOutputFile($dest, 'cabs.c');
-        push @cmd, '--cabsonly', $aftercil;
-    } else {
-        if(defined $self->{CILLY_OUT}) {
-            $aftercil = new App::Cilly::OutputFile($dest, $self->{CILLY_OUT});
-            return ($aftercil, @cmd);
-        }
-	$aftercil = $self->cilOutputFile($dest, 'cil.c');
-    }
-    return ($aftercil, @cmd, '--out', $aftercil);
-}
-
-sub MergeCommand {
-    my ($self, $ppsrc, $dir, $base) = @_;
-
-    return ('', $App::Cilly::CilCompiler::compiler);
-}
-
 
 1;

--- a/lib/perl5/App/Cilly/CilCompiler.pm
+++ b/lib/perl5/App/Cilly/CilCompiler.pm
@@ -1,0 +1,113 @@
+# Define here your favorite compiler by overriding Merger methods
+package App::Cilly::CilCompiler;
+
+use File::Basename;
+use strict;
+BEGIN {
+    @App::Cilly::CilCompiler::ISA = qw(App::Cilly);
+    $App::Cilly::CilCompiler::base =
+      "$FindBin::RealBin/$FindBin::RealScript";
+    # Use the most recent version of cilly
+    $App::Cilly::CilCompiler::mtime_native =
+    int((stat("$App::Cilly::CilCompiler::base.native"))[9]);
+    $App::Cilly::CilCompiler::mtime_byte =
+    int((stat("$App::Cilly::CilCompiler::base.byte"))[9]);
+    $App::Cilly::CilCompiler::use_debug =
+         grep(/--bytecode/, @ARGV) ||
+         grep(/--ocamldebug/, @ARGV) ||
+        ($App::Cilly::CilCompiler::mtime_native < $App::Cilly::CilCompiler::mtime_byte);
+    $App::Cilly::CilCompiler::compiler =
+        $App::Cilly::CilCompiler::base .
+            ($App::Cilly::CilCompiler::use_debug ? ".byte" : ".native");
+    if($App::Cilly::CilCompiler::use_debug) {
+        $ENV{"OCAMLRUNPARAM"} = "b" . $ENV{"OCAMLRUNPARAM"};
+    }
+    # Fix ocamlfind search path
+    if(open (my $input_fh, "<",
+        "$FindBin::RealBin/../share/cil/ocamlpath")) {
+      my $ocamlpath = <$input_fh>;
+      chomp($ocamlpath);
+      close $input_fh;
+      # ocamlpath separator is ':' on Unix, but ';' on Windows
+      my $ocamlsep = ($^O eq "MSWin32" || $^O eq "cygwin") ? ';' : ':';
+      $ENV{"OCAMLPATH"} = join($ocamlsep, $ocamlpath, $ENV{"OCAMLPATH"});
+    }
+}
+
+# We need to customize the collection of arguments
+sub collectOneArgument {
+    my($self, $arg, $pargs) = @_;
+    if($arg =~ m|--transval=(.+)$|)  {
+        $self->{TRANSVAL} = $1; return 1;
+    }
+    if($arg eq '--ocamldebug')  {
+        $self->{OCAMLDEBUG} = 1; return 1;
+    }
+    if($arg eq '--cabsonly') {
+        $self->{CABSONLY} = 1; return 1;
+    }
+    # See if the super class understands this
+    return $self->SUPER::collectOneArgument($arg, $pargs);
+}
+
+sub usage {
+    print "Usage: $FindBin::Script [options] [gcc_or_mscl arguments]\n";
+}
+
+sub helpMessage {
+    my($self) = @_;
+    # Print first the original
+    $self->SUPER::helpMessage();
+    print <<EOF;
+
+  All other arguments starting with -- are passed to the Cilly process.
+
+The following are the arguments of the Cilly process
+EOF
+   my @cmd = ($App::Cilly::CilCompiler::compiler, '--help');
+   if(defined $self->{CILARGS}) {
+       push @cmd, @{$self->{CILARGS}};
+   }
+   $self->runShell(@cmd);
+}
+
+
+sub CillyCommand {
+    my ($self, $ppsrc, $dest) = @_;
+
+    my $aftercil;
+    my @cmd = ($App::Cilly::CilCompiler::compiler);
+
+    if(defined $ENV{OCAMLDEBUG} || $self->{OCAMLDEBUG}) {
+        print "OCAMLDEBUG is on\n";
+        my @idirs = (".", "src", "src/frontc", "src/ext",
+                     "ocamlutil",
+                     "obj/");
+	my @iflags = map { ('-I', "$FindBin::RealBin/../$_") } @idirs;
+        unshift @cmd, 'ocamldebug', '-emacs', @iflags;
+    }
+    if($::docxx) {
+        push @cmd, '--cxx';
+    }
+    if($self->{CABSONLY}) {
+        $aftercil = $self->cilOutputFile($dest, 'cabs.c');
+        push @cmd, '--cabsonly', $aftercil;
+    } else {
+        if(defined $self->{CILLY_OUT}) {
+            $aftercil = new App::Cilly::OutputFile($dest, $self->{CILLY_OUT});
+            return ($aftercil, @cmd);
+        }
+	$aftercil = $self->cilOutputFile($dest, 'cil.c');
+    }
+    return ($aftercil, @cmd, '--out', $aftercil);
+}
+
+sub MergeCommand {
+    my ($self, $ppsrc, $dir, $base) = @_;
+
+    return ('', $App::Cilly::CilCompiler::compiler);
+}
+
+1;
+
+__END__

--- a/lib/perl5/Makefile.PL
+++ b/lib/perl5/Makefile.PL
@@ -12,6 +12,7 @@ WriteMakefile(
     PM                  => {
         'App/'.$Cilly.'.pm'      => '$(INST_LIBDIR)/App/'.$Cilly.'.pm',
         'App/'.$Cilly.'/CilConfig.pm' => '$(INST_LIBDIR)/App/'.$Cilly.'/CilConfig.pm',
+        'App/'.$Cilly.'/CilCompiler.pm' => '$(INST_LIBDIR)/App/'.$Cilly.'/CilCompiler.pm',
         'App/'.$Cilly.'/KeptFile.pm' => '$(INST_LIBDIR)/App/'.$Cilly.'/KeptFile.pm',
         'App/'.$Cilly.'/OutputFile.pm' => '$(INST_LIBDIR)/App/'.$Cilly.'/OutputFile.pm',
         'App/'.$Cilly.'/TempFile.pm' => '$(INST_LIBDIR)/App/'.$Cilly.'/TempFile.pm',


### PR DESCRIPTION
...a standalone perl module reusable from other CIL apps.  (Given the package naming, it actually might have been the original intention.)

This helps other CIL apps reuse this perl module for their own perl driver scripts.  E.g.

https://github.com/pmundkur/ccured-hack/commit/368e0361f409d3d57de951d46c1b047d7cb65f47
