### PR TITLE
Pass compiler options with '='

### DIFF
--- a/lib/perl5/App/Cilly.pm.in
+++ b/lib/perl5/App/Cilly.pm.in
@@ -1962,7 +1962,7 @@ sub new {
             "-pedantic-errors\$" => { TYPE => 'ALLARGS' },
             "-Wall" => { TYPE => 'CC', 
 			 RUN => sub { push @{$stub->{CILARGS}},"--warnall";}},
-            "-W[-a-z0-9]*\$" => { TYPE => 'CC' },
+            "-W[-a-z0-9=]*\$" => { TYPE => 'CC' },
             "-w\$" => { TYPE => 'ALLARGS' },
 
 	    # Debugging Options


### PR DESCRIPTION
When cilly attempts to figure out what to do with the arguments it
receives, it wasn't able to identify stuff like -Wformat=2 or
-Wnormalized=id. Teach it that '=' signs in arguments are OK for gcc.
