### PR TITLE
This pull request solves two minor bugs and a more important one

### DIFF
--- a/src/frontc/cparser.mly
+++ b/src/frontc/cparser.mly
@@ -1542,7 +1542,11 @@ asmopname:
 
 asmclobber:
     /* empty */                         { [] }
-| COLON asmcloberlst_ne                 { $2 }
+| COLON asmcloberlst                    { $2 }
+;
+asmcloberlst:
+    /* empty */                         { [] }
+| asmcloberlst_ne                       { $1 }
 ;
 asmcloberlst_ne:
    one_string_constant                           { [$1] }

--- a/test/Makefile
+++ b/test/Makefile
@@ -363,6 +363,14 @@ mergestruct: $(TESTDIR)/small2/mergestruct1.c $(TESTDIR)/small2/mergestruct2.c
 	  $(CILLY) mergestruct1.c mergestruct2.c -o mergestruct.exe
 	$(TESTDIR)/small2/mergestruct.exe
 
+# sc: this tests for a merger bug in global variables initializations
+mergeinit: $(TESTDIR)/small2/mergeinit1.h $(TESTDIR)/small2/mergeinit1.c \
+           $(TESTDIR)/small2/mergeinit2.h $(TESTDIR)/small2/mergeinit2_1_reftable.c $(TESTDIR)/small2/mergeinit2_2_definition.c \
+           $(TESTDIR)/small2/mergeinit3.h $(TESTDIR)/small2/mergeinit3.c \
+           $(TESTDIR)/small2/mergeinit4.c
+	cd $(TESTDIR)/small2; \
+	  $(CILLY) --merge --strictcheck --keepunused mergeinit1.c mergeinit2_1_reftable.c mergeinit2_2_definition.c mergeinit3.c mergeinit4.c
+
 # sm: yet another merger test (I know there's a target somewhere)
 mergeinline: $(TESTDIR)/small2/mergeinline1.c $(TESTDIR)/small2/mergeinline2.c
 	cd $(TESTDIR)/small2; \

--- a/test/small1/asm_emptyclobberallowed.c
+++ b/test/small1/asm_emptyclobberallowed.c
@@ -1,0 +1,8 @@
+
+int main(){
+  asm ("xor %%eax, %%eax"
+       : /* No outputs. */
+       : /* No inputs */
+       : );
+  return(0);
+}

--- a/test/small2/mergeinit1.c
+++ b/test/small2/mergeinit1.c
@@ -1,0 +1,7 @@
+
+int f1(void)
+{
+	return(1);
+}
+
+

--- a/test/small2/mergeinit1.h
+++ b/test/small2/mergeinit1.h
@@ -1,0 +1,2 @@
+
+extern int f1(void);

--- a/test/small2/mergeinit2.h
+++ b/test/small2/mergeinit2.h
@@ -1,0 +1,2 @@
+
+extern int (*table[2])();

--- a/test/small2/mergeinit2_1_reftable.c
+++ b/test/small2/mergeinit2_1_reftable.c
@@ -1,0 +1,2 @@
+#include "mergeinit2.h"
+

--- a/test/small2/mergeinit2_2_definition.c
+++ b/test/small2/mergeinit2_2_definition.c
@@ -1,0 +1,10 @@
+#include "mergeinit1.h"
+#include "mergeinit2.h"
+#include "mergeinit3.h"
+
+
+int (*table[2])(void) =
+{
+      &f1,
+      &f3
+};

--- a/test/small2/mergeinit3.c
+++ b/test/small2/mergeinit3.c
@@ -1,0 +1,7 @@
+
+int f3(void)
+{
+	return(3);
+}
+
+

--- a/test/small2/mergeinit3.h
+++ b/test/small2/mergeinit3.h
@@ -1,0 +1,2 @@
+
+extern int f3(void);

--- a/test/small2/mergeinit4.c
+++ b/test/small2/mergeinit4.c
@@ -1,0 +1,5 @@
+#include "mergeinit2.h"
+
+int main(){
+	return(table[0]());
+}

--- a/test/testcil.pl
+++ b/test/testcil.pl
@@ -198,6 +198,7 @@ addTest("testrun/asm1 _GNUCC=1");
 addTest("test/asm2 _GNUCC=1");
 addTest("test/asm3 _GNUCC=1");
 addTest("test/asm4 _GNUCC=1");
+addTest("test/asm_emptyclobberallowed _GNUCC=1");
 addTest("testobj/asm5 _GNUCC=1");
 
 addTest("testrun/offsetof");

--- a/test/testcil.pl
+++ b/test/testcil.pl
@@ -654,6 +654,9 @@ addBadComment("testrun/constfold", "Bug. Wrong constant folding.  #2276515 on so
 # tests of things implemented for EDG compatibility
 addTest("mergestruct");
 
+# Test for a merge bug in global variables initializations
+addTest("mergeinit");
+
 # a few things that should fail
 addTest("test-bad/trivial-tb");
 addTest("runall/runall_misc");


### PR DESCRIPTION
- Oversight: the syntax for the __asm construct misses an empty entry
- Size_t on 8 bytes: this allow a correct compilaton of CIL on mingw x86_64
- Initialization bug: see the rest of this pull request

Global variables initializations may refer to function pointers. If the variables appear in several C files to be merged (as declarations and/or definitions), depending on the order in which the merge is done, their initializations may be incorrectly unified.

Please find the attached minimal example with a source to be compiled and a subdirectory (to be passed to the executable) that contains the example.
[minimal-example.zip](https://github.com/cil-project/cil/files/190553/minimal-example.zip)
Note: the code in the example is not legal C code (it uses variables instead of function pointers), but I think it conveys the idea of the bug better.

The source file uses cilPrinter that displays the vid of the varinfos. When displaying the merged files with this printer, one ends up with:

```
Preprocessing ../sources/test4/mod2.c
Preprocessing ../sources/test4/mod1.c
Preprocessing ../sources/test4/mod4.c
Preprocessing ../sources/test4/mod3_1_usage.c
Preprocessing ../sources/test4/mod3_2_definition.c
Sort order before merge: mod1.i,mod2.i,mod3_1_usage.i,mod3_2_definition.i,mod4.i
/* Generated by CIL v. 1.7.3 */
/* print_CIL_Input is false */

int const   var1 [570];
int const   var1 [570] =    (int const   )0;
int const   var2 [1141];
int const   var2 [1141] =    (int const   )1;
int table[3] [284];
void doStuff(void) [285]
{ 
  int x [287];

  {
  x[287] = table[284][1];
  return;
}
}
int const   var4 [856];
int table[3] [284] = {      (int )var1[854],      (int )var2[855],      (int )var4[856]};
int const   var4 [856] =    (int const   )2;
```

One can see that the `var1` and `var2` in the initialization of `table` do not have the correct vid. 

While this is not legal C code (gcc will not accept it), this is what happens when var1 and var2 are function pointers (in which case it is legal C code).
