### PR TITLE
Load binary files without global state conflicts

### DIFF
--- a/src/cil.mli
+++ b/src/cil.mli
@@ -1170,8 +1170,9 @@ val saveBinaryFileChannel : file -> out_channel -> unit
 
 (** Read a {!Cil.file} in binary form from the filesystem. The first
  * argument is the name of a file previously created by
- * {!Cil.saveBinaryFile}. Because this also reads some global state,
- * this should be called before any other CIL code is parsed or generated. *)
+ * {!Cil.saveBinaryFile}. Be aware that the varinfo vid and compinfo ckey
+ * fields shall be modified to avoid conflicts with the currently used
+ * varinfo and compinfo values. *)
 val loadBinaryFile : string -> file 
 
 (** Get the global initializer and create one if it does not already exist. 


### PR DESCRIPTION
Hi,
this commit adds the ability to use loadBinaryFile at leisure, without having global state problems thereafter. The algorithm to do so is imho simple enough, without causing vid or ckey overflow if one is to save/reload the same file many times over several executions (the overflow problem could most probably arise realistically on 32bit OCaml, but I'd rather be cautious).

I did not add a test in the test suite, because cilly does not load/save binary files unfortunately. :neutral_face: 
