### PR TITLE
Ciltrace

### DIFF
--- a/src/cil.ml
+++ b/src/cil.ml
@@ -39,7 +39,7 @@
 open Escape
 open Pretty
 open Cilint
-(* open Trace      (\* sm: 'trace' function *\) *)
+(* open Ciltrace      (\* sm: 'trace' function *\) *)
 module E = Errormsg
 module H = Hashtbl
 module IH = Inthash

--- a/src/cil.mllib
+++ b/src/cil.mllib
@@ -10,6 +10,7 @@ Cil
 Cilint
 Cillower
 Ciloptions
+Ciltrace
 Cilutil
 Cilversion
 Clexer
@@ -37,6 +38,5 @@ Patch
 Pretty
 Rmtmps
 Stats
-Trace
 Util
 Whitetrack

--- a/src/ciloptions.ml
+++ b/src/ciloptions.ml
@@ -236,7 +236,7 @@ let options : (string * Arg.spec * string) list =
 
     (* sm: some more debugging options *)
     "--tr",
-    Arg.String Trace.traceAddMulti,
+    Arg.String Ciltrace.traceAddMulti,
     "<sys> Subsystem to show debug printfs for";
 
     "--extrafiles",

--- a/src/ext/callgraph/callgraph.ml
+++ b/src/ext/callgraph/callgraph.ml
@@ -5,7 +5,7 @@
 
 open Cil
 open Feature
-open Trace
+open Ciltrace
 open Printf
 module P = Pretty
 module IH = Inthash

--- a/src/ext/epicenter/epicenter.ml
+++ b/src/ext/epicenter/epicenter.ml
@@ -7,7 +7,7 @@
 open Callgraph
 open Cil
 open Feature
-open Trace
+open Ciltrace
 open Pretty
 module H = Hashtbl
 module IH = Inthash

--- a/src/ext/logcalls/logcalls.ml
+++ b/src/ext/logcalls/logcalls.ml
@@ -5,7 +5,7 @@
 open Pretty
 open Cil
 open Feature
-open Trace
+open Ciltrace
 module E = Errormsg
 module H = Hashtbl
 

--- a/src/ext/zrapp/zrapp.ml
+++ b/src/ext/zrapp/zrapp.ml
@@ -1,7 +1,7 @@
 
 open Escape
 open Pretty
-open Trace
+open Ciltrace
 open Cil
 open Feature
 

--- a/src/formatcil.ml
+++ b/src/formatcil.ml
@@ -36,7 +36,7 @@
  *)
 open Cil
 open Pretty
-open Trace      (* sm: 'trace' function *)
+open Ciltrace      (* sm: 'trace' function *)
 module E = Errormsg
 module H = Hashtbl
 

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -51,7 +51,7 @@ open Cabshelper
 open Pretty
 open Cil
 open Cilint
-open Trace
+open Ciltrace
 
 
 let mydebugfunction () = 

--- a/src/frontc/cabsvisit.ml
+++ b/src/frontc/cabsvisit.ml
@@ -40,7 +40,7 @@
 
 open Cabs
 open Cabshelper
-open Trace
+open Ciltrace
 open Pretty
 module E = Errormsg
 

--- a/src/frontc/frontc.ml
+++ b/src/frontc/frontc.ml
@@ -37,7 +37,7 @@
 
 
 module E = Errormsg
-open Trace
+open Ciltrace
 open Pretty
 
 (* Output management *)

--- a/src/frontc/patch.ml
+++ b/src/frontc/patch.ml
@@ -41,7 +41,7 @@
 
 open Cabs
 open Cabshelper
-open Trace
+open Ciltrace
 open Pretty
 open Cabsvisit
 

--- a/src/mergecil.ml
+++ b/src/mergecil.ml
@@ -47,7 +47,7 @@ open Cil
 module E = Errormsg
 module H = Hashtbl
 module A = Alpha
-open Trace
+open Ciltrace
 
 let debugMerge = false
 let debugInlines = false

--- a/src/ocamlutil/ciltrace.ml
+++ b/src/ocamlutil/ciltrace.ml
@@ -35,7 +35,7 @@
  *
  *)
 
-(* Trace module implementation
+(* Ciltrace module implementation
  * see trace.mli
  *)
 

--- a/src/ocamlutil/ciltrace.mli
+++ b/src/ocamlutil/ciltrace.mli
@@ -35,7 +35,7 @@
  *
  *)
 
-(* Trace module
+(* Ciltrace module
  * Scott McPeak, 5/4/00
  *
  * The idea is to pepper the source with debugging printfs,

--- a/src/rmtmps.ml
+++ b/src/rmtmps.ml
@@ -50,7 +50,7 @@ let keepUnused = ref false
 let rmUnusedInlines = ref false
 
 
-let trace = Trace.trace "rmtmps"
+let trace = Ciltrace.trace "rmtmps"
 
 
 
@@ -802,14 +802,14 @@ type rootsFilter = global -> bool
 let isDefaultRoot = isExportedRoot
 
 let rec removeUnusedTemps ?(isRoot : rootsFilter = isDefaultRoot) file =
-  if !keepUnused || Trace.traceActive "disableTmpRemoval" then
-    Trace.trace "disableTmpRemoval" (dprintf "temp removal disabled\n")
+  if !keepUnused || Ciltrace.traceActive "disableTmpRemoval" then
+    Ciltrace.trace "disableTmpRemoval" (dprintf "temp removal disabled\n")
   else
     begin
       if !E.verboseFlag then 
         ignore (E.log "Removing unused temporaries\n" );
 
-      if Trace.traceActive "printCilTree" then
+      if Ciltrace.traceActive "printCilTree" then
 	dumpFile defaultCilPrinter stdout "stdout" file;
 
       (* digest any pragmas that would create additional roots *)


### PR DESCRIPTION
Trace was a bad choice of name for a module inside CIL. It prevents the OCAML toplevel from linking.

ocamlmktop -o cilmain -I ocamlfind -query cil nums.cma unix.cma str.cma cil.cma cilmain.cmo
File "/home/jrrk2/.opam/4.03.0/lib/cil/cil.cma(Trace)", line 1:
Warning 31: files /home/jrrk2/.opam/4.03.0/lib/cil/cil.cma(Trace) and
/home/jrrk2/.opam/4.03.0/lib/ocaml/compiler-libs/ocamltoplevel.cma(Trace) both define a module named Trace
Error: Some fatal warnings were triggered (1 occurrences)

The attached pull request fixes the issue and allows Cil data structures to be accessed from the OCaml toplevel.