### PR TITLE
Address various deprecation warnings.

### DIFF
--- a/src/cil.ml
+++ b/src/cil.ml
@@ -2713,7 +2713,7 @@ let parseInt (str: string) : exp =
     let l = String.length str in
     fun s -> 
       let ls = String.length s in
-      l >= ls && s = String.uppercase (String.sub str (l - ls) ls)
+      l >= ls && s = String.uppercase_ascii (String.sub str (l - ls) ls)
   in
   let l = String.length str in
   (* See if it is octal or hex *)
@@ -5090,7 +5090,7 @@ let makeValidSymbolName (s: string) =
       | _ -> false
     in
     if isinvalid then 
-      String.set s i '_';
+      Bytes.set s i '_';
   done;
   s
 

--- a/src/cil.ml
+++ b/src/cil.ml
@@ -5080,10 +5080,10 @@ let loadBinaryFile (filename : string) : file =
 (* Take the name of a file and make a valid symbol name out of it. There are 
  * a few characters that are not valid in symbols *)
 let makeValidSymbolName (s: string) = 
-  let s = String.copy s in (* So that we can update in place *)
-  let l = String.length s in
+  let s = Bytes.of_string s in (* strings are immutable; convert to mutable Bytes *)
+  let l = Bytes.length s in
   for i = 0 to l - 1 do
-    let c = String.get s i in
+    let c = Bytes.get s i in
     let isinvalid = 
       match c with
         '-' | '.' -> true
@@ -5092,7 +5092,7 @@ let makeValidSymbolName (s: string) =
     if isinvalid then 
       Bytes.set s i '_';
   done;
-  s
+  Bytes.to_string s
 
 let rec addOffset (toadd: offset) (off: offset) : offset =
   match off with

--- a/src/ext/partial/heap.ml
+++ b/src/ext/partial/heap.ml
@@ -9,7 +9,7 @@ type ('a) t = {
 } 
 
 let create size = {
-  elements = Array.create (size+1) (max_int,None) ;
+  elements = Array.make (size+1) (max_int,None) ;
   size = 0 ;
   capacity = size ; 
 } 

--- a/src/formatlex.mll
+++ b/src/formatlex.mll
@@ -145,11 +145,11 @@ let scan_oct_escape str =
  * We convert L"Hi" to "H\000i\000" *)
 let wbtowc wstr =
   let len = String.length wstr in 
-  let dest = String.make (len * 2) '\000' in 
+  let dest = Bytes.make (len * 2) '\000' in 
   for i = 0 to len-1 do 
     dest.[i*2] <- wstr.[i] ;
   done ;
-  dest
+  Bytes.to_string dest
 
 (* This function converst the "Hi" in L"Hi" to { L'H', L'i', L'\0' } *)
 let wstr_to_warray wstr =

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -1924,7 +1924,7 @@ let rec setOneInit (this: preInit)
       let pMaxIdx, pArray = 
         match this  with 
           NoInitPre  -> (* No initializer so far here *)
-            ref idx, ref (Array.create (max 32 (idx + 1)) NoInitPre)
+            ref idx, ref (Array.make (max 32 (idx + 1)) NoInitPre)
               
         | CompoundPre (pMaxIdx, pArray) -> 
             if !pMaxIdx < idx then begin 
@@ -3417,7 +3417,7 @@ and doExp (asconst: bool)   (* This expression is used as a constant *)
           let l = String.length str in
           fun s -> 
             let ls = String.length s in
-            l >= ls && s = String.uppercase (String.sub str (l - ls) ls)
+            l >= ls && s = String.uppercase_ascii (String.sub str (l - ls) ls)
         in
         match ct with 
           A.CONST_INT str -> begin

--- a/src/ocamlutil/bitmap.ml
+++ b/src/ocamlutil/bitmap.ml
@@ -10,7 +10,7 @@ type t = { mutable nrWords  : int;
 let enlarge b newWords = 
   let newbitmap = 
     if newWords > b.nrWords then
-      let a = Array.create newWords Int32.zero in
+      let a = Array.make newWords Int32.zero in
       Array.blit b.bitmap 0 a 0 b.nrWords;
       a
     else

--- a/src/ocamlutil/errormsg.ml
+++ b/src/ocamlutil/errormsg.ml
@@ -217,9 +217,9 @@ let cleanFileName str =
      else 
        let c = String.get str1 i in
        if c <> '\\' then begin
-          String.set str1 copyto c; loop (copyto + 1) (i + 1)
+          Bytes.set str1 copyto c; loop (copyto + 1) (i + 1)
        end else begin
-          String.set str1 copyto '/';
+          Bytes.set str1 copyto '/';
           if i < l - 2 && String.get str1 (i + 1) = '\\' then
               loop (copyto + 1) (i + 2)
           else 

--- a/src/ocamlutil/errormsg.ml
+++ b/src/ocamlutil/errormsg.ml
@@ -206,27 +206,28 @@ let setHFile (f: string) : unit =
 let rem_quotes str = String.sub str 1 ((String.length str) - 2)
 
 (* Change \ into / in file names. To avoid complications with escapes *)
+(* Change \ into / in file names. To avoid complications with escapes *)
 let cleanFileName str = 
   let str1 = 
     if str <> "" && String.get str 0 = '"' (* '"' ( *) 
-    then rem_quotes str else str in
-  let l = String.length str1 in
+    then Bytes.of_string (rem_quotes str) else Bytes.of_string str in
+  let l = Bytes.length str1 in
   let rec loop (copyto: int) (i: int) = 
     if i >= l then 
-      String.sub str1 0 copyto
+      Bytes.sub str1 0 copyto
      else 
-       let c = String.get str1 i in
+       let c = Bytes.get str1 i in
        if c <> '\\' then begin
           Bytes.set str1 copyto c; loop (copyto + 1) (i + 1)
        end else begin
           Bytes.set str1 copyto '/';
-          if i < l - 2 && String.get str1 (i + 1) = '\\' then
+          if i < l - 2 && Bytes.get str1 (i + 1) = '\\' then
               loop (copyto + 1) (i + 2)
           else 
               loop (copyto + 1) (i + 1)
        end
   in
-  loop 0 0
+  Bytes.to_string (loop 0 0)
 
 let readingFromStdin = ref false
 

--- a/src/ocamlutil/inthash.ml
+++ b/src/ocamlutil/inthash.ml
@@ -34,7 +34,7 @@ let resize tbl =
   let osize = Array.length odata in
   let nsize = min (2 * osize + 1) Sys.max_array_length in
   if nsize <> osize then begin
-    let ndata = Array.create nsize Empty in
+    let ndata = Array.make nsize Empty in
     let rec insert_bucket = function
         Empty -> ()
       | Cons(key, data, rest) ->

--- a/src/ocamlutil/longarray.ml
+++ b/src/ocamlutil/longarray.ml
@@ -24,7 +24,7 @@ let split_idx (idx: int) : int option =
 
 let rec create (len: int) (init: 'a) : 'a t =
   let len1, len2 = split_len len in
-  (Array.create len1 init) :: (if len2 > 0 then create len2 init else [])
+  (Array.make len1 init) :: (if len2 > 0 then create len2 init else [])
 
 let rec init (len: int) (fn: int -> 'a) : 'a t =
   let len1, len2 = split_len len in

--- a/src/ocamlutil/pretty.ml
+++ b/src/ocamlutil/pretty.ml
@@ -726,7 +726,7 @@ let gprintf (finish : doc -> 'b)
 			   ^ (String.sub format i (j-i+1)));
 	    let j' = succ j in (* eat the d,i,x etc. *)
 	    let format_spec = "% " in
-	    String.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
+	    Bytes.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
             Obj.magic(fun n ->
               collect (dctext1 acc
                          (Int64.format format_spec n))
@@ -736,7 +736,7 @@ let gprintf (finish : doc -> 'b)
 					    ^ (String.sub format i (j-i+1)));
 	    let j' = succ j in (* eat the d,i,x etc. *)
 	    let format_spec = "% " in
-	    String.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
+	    Bytes.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
             Obj.magic(fun n ->
               collect (dctext1 acc
                          (Int32.format format_spec n))
@@ -746,7 +746,7 @@ let gprintf (finish : doc -> 'b)
 					    ^ (String.sub format i (j-i+1)));
 	    let j' = succ j in (* eat the d,i,x etc. *)
 	    let format_spec = "% " in
-	    String.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
+	    Bytes.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
             Obj.magic(fun n ->
               collect (dctext1 acc
                          (Nativeint.format format_spec n))

--- a/src/ocamlutil/pretty.ml
+++ b/src/ocamlutil/pretty.ml
@@ -725,31 +725,31 @@ let gprintf (finish : doc -> 'b)
               invalid_arg ("dprintf: unimplemented format " 
 			   ^ (String.sub format i (j-i+1)));
 	    let j' = succ j in (* eat the d,i,x etc. *)
-	    let format_spec = "% " in
+	    let format_spec = Bytes.of_string "% " in
 	    Bytes.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
             Obj.magic(fun n ->
               collect (dctext1 acc
-                         (Int64.format format_spec n))
+                         (Int64.format (Bytes.to_string format_spec) n))
                 (succ j'))
 	| 'l' ->
 	    if j != i + 1 then invalid_arg ("dprintf: unimplemented format " 
 					    ^ (String.sub format i (j-i+1)));
 	    let j' = succ j in (* eat the d,i,x etc. *)
-	    let format_spec = "% " in
+	    let format_spec = Bytes.of_string "% " in
 	    Bytes.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
             Obj.magic(fun n ->
               collect (dctext1 acc
-                         (Int32.format format_spec n))
+                         (Int32.format (Bytes.to_string format_spec) n))
                 (succ j'))
 	| 'n' ->
 	    if j != i + 1 then invalid_arg ("dprintf: unimplemented format " 
 					    ^ (String.sub format i (j-i+1)));
 	    let j' = succ j in (* eat the d,i,x etc. *)
-	    let format_spec = "% " in
+	    let format_spec = Bytes.of_string "% " in
 	    Bytes.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
             Obj.magic(fun n ->
               collect (dctext1 acc
-                         (Nativeint.format format_spec n))
+                         (Nativeint.format (Bytes.to_string format_spec) n))
                 (succ j'))
         | 'f' | 'e' | 'E' | 'g' | 'G' ->
             Obj.magic(fun f ->


### PR DESCRIPTION
As of OCaml 4.02:
- Bytes module is introduced
-  Strings are immutable, so String.set and String.copy are deprecated.

To the latter point, the changes to Pretty and Errormsg are only necessary for compilation in 4.06; behavior should be the same in previous versions.

As of OCaml 4.03:
- Array.create is deprecated
- String.uppercase deprecated; replace with uppercase_ascii

I have confirmed compilation in 4.03, 4.04, and 4.06.0+trunk (with other changes to fix the Num module movement problem, a different PR) on Darwin.  I have run "make test", and the same tests fail before and after the changes (which really should be semantics-preserving). 