### PR TITLE
Replace Num with ZArith for Cilint (for OCaml 4.06.0).

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -106,7 +106,7 @@ ocamlbuild:
 META:
 	@rm -f $@
 	@printf "description = \"C Intermediate Language\"\n" >>$@
-	@printf "requires = \"unix str num dynlink\"\n" >>$@
+	@printf "requires = \"unix str zarith dynlink\"\n" >>$@
 	@printf "version = \"$(CIL_VERSION)\"\n\n" >>$@
 	@printf "archive(byte) = \"cil.cma\"\n" >>$@
 	@printf "archive(native) = \"cil.cmxa\"\n\n" >>$@

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ check out the accompanying [project template][template].
 Installation
 -----------
 
-To build and install CIL, you need the OCaml compiler, perl, and
-[ocamlfind][findlib].  (Of course, you also need some C compiler,
+To build and install CIL, you need the OCaml compiler, perl, the [zarith]
+module and [ocamlfind][findlib].  (Of course, you also need some C compiler,
 preferably gcc.)
 
 Run the following commands to build and install CIL:
@@ -50,6 +50,7 @@ directory:
 
 [findlib]: http://projects.camlcity.org/projects/findlib.html
 [opam]: http://opam.ocamlpro.com/
+[zarith]: https://github.com/ocaml/Zarith
 
 Usage
 -----

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -17,12 +17,21 @@ let find_modules builder mllib =
   (String.concat " " built_files) ^ " "
 ;;
 
+let ocamlfind_query pkg =
+  let cmd = Printf.sprintf "ocamlfind query %s" (Filename.quote pkg) in
+  Ocamlbuild_pack.My_unix.run_and_open cmd (fun ic ->
+      input_line ic
+    )
+
 let cil_version =
   try Printf.sprintf "(version %s)" (Sys.getenv "CIL_VERSION")
   with Not_found -> "" ;;
 
 dispatch begin function
 | After_rules ->
+    (* zarith exists *)
+  ocaml_lib ~extern:true ~dir:(ocamlfind_query "zarith") "zarith";
+
     (* the main CIL library *)
     ocaml_lib "src/cil";
 

--- a/src/_tags
+++ b/src/_tags
@@ -1,4 +1,5 @@
 <ext> or <ext/*> or <frontc> or <ocamlutil>: include
 
 <feature.ml>: package(findlib)
-<main.{byte,native}>: use_unix, use_str, use_nums, use_dynlink, use_cil, linkall, package(findlib)
+<main.{byte,native}>: use_unix, use_str, use_dynlink, use_cil, linkall, package(findlib)
+<cilint.*>: use_zarith

--- a/src/_tags
+++ b/src/_tags
@@ -1,5 +1,5 @@
 <ext> or <ext/*> or <frontc> or <ocamlutil>: include
 
 <feature.ml>: package(findlib)
-<main.{byte,native}>: use_unix, use_str, use_dynlink, use_cil, linkall, package(findlib)
+<main.{byte,native}>: use_unix, use_str, use_dynlink, use_cil, use_zarith, linkall, package(findlib)
 <cilint.*>: use_zarith

--- a/src/cil.ml
+++ b/src/cil.ml
@@ -2713,7 +2713,7 @@ let parseInt (str: string) : exp =
     let l = String.length str in
     fun s -> 
       let ls = String.length s in
-      l >= ls && s = String.uppercase (String.sub str (l - ls) ls)
+      l >= ls && s = String.uppercase_ascii (String.sub str (l - ls) ls)
   in
   let l = String.length str in
   (* See if it is octal or hex *)
@@ -5090,7 +5090,7 @@ let makeValidSymbolName (s: string) =
       | _ -> false
     in
     if isinvalid then 
-      String.set s i '_';
+      Bytes.set s i '_';
   done;
   s
 

--- a/src/cil.ml
+++ b/src/cil.ml
@@ -5080,10 +5080,10 @@ let loadBinaryFile (filename : string) : file =
 (* Take the name of a file and make a valid symbol name out of it. There are 
  * a few characters that are not valid in symbols *)
 let makeValidSymbolName (s: string) = 
-  let s = String.copy s in (* So that we can update in place *)
-  let l = String.length s in
+  let s = Bytes.of_string s in (* strings are immutable; convert to mutable Bytes *)
+  let l = Bytes.length s in
   for i = 0 to l - 1 do
-    let c = String.get s i in
+    let c = Bytes.get s i in
     let isinvalid = 
       match c with
         '-' | '.' -> true
@@ -5092,7 +5092,7 @@ let makeValidSymbolName (s: string) =
     if isinvalid then 
       Bytes.set s i '_';
   done;
-  s
+  Bytes.to_string s
 
 let rec addOffset (toadd: offset) (off: offset) : offset =
   match off with

--- a/src/cilint.ml
+++ b/src/cilint.ml
@@ -21,9 +21,9 @@
    bitwise operations on big_ints, and bug-fixed versions of int64_of_big_int
    and big_int_of_int64. *)
 
-open Big_int
-  
-type cilint = Small of int | Big of big_int
+open Z
+
+type cilint = Small of int | Big of Z.t
 type truncation = NoTruncation | ValueTruncation | BitTruncation
 
 let zero_cilint = Small 0

--- a/src/cilint.ml
+++ b/src/cilint.ml
@@ -20,9 +20,6 @@
    The implementation can be simplified once OCaml 3.11.1 shows up, with
    bitwise operations on big_ints, and bug-fixed versions of int64_of_big_int
    and big_int_of_int64. *)
-(* CLG notes: it's not obvious to me that we need all this; it might make
-   more sense to just transition all of Cil to Z/Zarith.  However, I'm making
-   the small/local change for now *)
 
 type cilint = Small of int | Big of Z.t
 type truncation = NoTruncation | ValueTruncation | BitTruncation
@@ -36,7 +33,7 @@ let m1 = Z.minus_one
 let two = Z.of_int 2
 
 (* True if 'b' is all 0's or all 1's *)
-let nobits (b:Z.t) : bool = (* CLG: the equality b/w minus 1 and b here isn't obvious to me, double-check *)
+let nobits (b:Z.t) : bool = 
   Z.sign b = 0 || Z.equal b m1
 
 let big_int_of_cilint (c:cilint) : Z.t = 
@@ -66,7 +63,7 @@ let add_cilint = b Z.add
 let sub_cilint = b Z.sub
 let mul_cilint = b Z.mul
 let div_cilint = b Z.div
-let mod_cilint = b Z.rem (* CLG: remember to check when sinus headache goes away that rem <--> mod *) 
+let mod_cilint = b Z.rem 
 
 
 let compare_cilint (c1:cilint) (c2:cilint) : int = 
@@ -89,7 +86,7 @@ let cilint_of_int (i:int) : cilint = Small i
 let int_of_cilint (c:cilint) : int = 
   match c with 
   | Small i -> i
-  | Big b -> Z.to_int b (* CLG: to_int might overflow, was that true of bigint? I assume yes? *)
+  | Big b -> Z.to_int b
 
 let rec cilint_of_int64 (i64:int64) : cilint = 
   if Int64.compare i64 (Int64.of_int min_int) >= 0 && 

--- a/src/cilint.mli
+++ b/src/cilint.mli
@@ -3,7 +3,7 @@
 (** The cilint type is public and not just big_int to make life with ocamldebug
     easier. Please do not rely on this representation, use the ..._of_cilint
     functions to get at a cilint's value. *)
-type cilint = Small of int | Big of Big_int.big_int
+type cilint = Small of int | Big of Z.t
 
 (** 0 as a cilint *)
 val zero_cilint : cilint
@@ -85,7 +85,7 @@ val int_of_cilint : cilint -> int
 val int64_of_cilint : cilint -> int64
 
 (** Return the cilint's value as a big_int *)
-val big_int_of_cilint : cilint -> Big_int.big_int
+val big_int_of_cilint : cilint -> Z.t
 
 (** Return the cilint's value as a string *)
 val string_of_cilint : cilint -> string
@@ -97,7 +97,7 @@ val cilint_of_int : int -> cilint
 val cilint_of_int64 : int64 -> cilint
 
 (** Make a cilint from a big_int *)
-val cilint_of_big_int : Big_int.big_int -> cilint
+val cilint_of_big_int : Z.t -> cilint
 
 (** Make a cilint from a string *)
 val cilint_of_string : string -> cilint

--- a/src/ext/partial/heap.ml
+++ b/src/ext/partial/heap.ml
@@ -9,7 +9,7 @@ type ('a) t = {
 } 
 
 let create size = {
-  elements = Array.create (size+1) (max_int,None) ;
+  elements = Array.make (size+1) (max_int,None) ;
   size = 0 ;
   capacity = size ; 
 } 

--- a/src/formatlex.mll
+++ b/src/formatlex.mll
@@ -145,11 +145,11 @@ let scan_oct_escape str =
  * We convert L"Hi" to "H\000i\000" *)
 let wbtowc wstr =
   let len = String.length wstr in 
-  let dest = String.make (len * 2) '\000' in 
+  let dest = Bytes.make (len * 2) '\000' in 
   for i = 0 to len-1 do 
     dest.[i*2] <- wstr.[i] ;
   done ;
-  dest
+  Bytes.to_string dest
 
 (* This function converst the "Hi" in L"Hi" to { L'H', L'i', L'\0' } *)
 let wstr_to_warray wstr =

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -1924,7 +1924,7 @@ let rec setOneInit (this: preInit)
       let pMaxIdx, pArray = 
         match this  with 
           NoInitPre  -> (* No initializer so far here *)
-            ref idx, ref (Array.create (max 32 (idx + 1)) NoInitPre)
+            ref idx, ref (Array.make (max 32 (idx + 1)) NoInitPre)
               
         | CompoundPre (pMaxIdx, pArray) -> 
             if !pMaxIdx < idx then begin 
@@ -3417,7 +3417,7 @@ and doExp (asconst: bool)   (* This expression is used as a constant *)
           let l = String.length str in
           fun s -> 
             let ls = String.length s in
-            l >= ls && s = String.uppercase (String.sub str (l - ls) ls)
+            l >= ls && s = String.uppercase_ascii (String.sub str (l - ls) ls)
         in
         match ct with 
           A.CONST_INT str -> begin

--- a/src/ocamlutil/bitmap.ml
+++ b/src/ocamlutil/bitmap.ml
@@ -10,7 +10,7 @@ type t = { mutable nrWords  : int;
 let enlarge b newWords = 
   let newbitmap = 
     if newWords > b.nrWords then
-      let a = Array.create newWords Int32.zero in
+      let a = Array.make newWords Int32.zero in
       Array.blit b.bitmap 0 a 0 b.nrWords;
       a
     else

--- a/src/ocamlutil/errormsg.ml
+++ b/src/ocamlutil/errormsg.ml
@@ -217,9 +217,9 @@ let cleanFileName str =
      else 
        let c = String.get str1 i in
        if c <> '\\' then begin
-          String.set str1 copyto c; loop (copyto + 1) (i + 1)
+          Bytes.set str1 copyto c; loop (copyto + 1) (i + 1)
        end else begin
-          String.set str1 copyto '/';
+          Bytes.set str1 copyto '/';
           if i < l - 2 && String.get str1 (i + 1) = '\\' then
               loop (copyto + 1) (i + 2)
           else 

--- a/src/ocamlutil/errormsg.ml
+++ b/src/ocamlutil/errormsg.ml
@@ -206,27 +206,28 @@ let setHFile (f: string) : unit =
 let rem_quotes str = String.sub str 1 ((String.length str) - 2)
 
 (* Change \ into / in file names. To avoid complications with escapes *)
+(* Change \ into / in file names. To avoid complications with escapes *)
 let cleanFileName str = 
   let str1 = 
     if str <> "" && String.get str 0 = '"' (* '"' ( *) 
-    then rem_quotes str else str in
-  let l = String.length str1 in
+    then Bytes.of_string (rem_quotes str) else Bytes.of_string str in
+  let l = Bytes.length str1 in
   let rec loop (copyto: int) (i: int) = 
     if i >= l then 
-      String.sub str1 0 copyto
+      Bytes.sub str1 0 copyto
      else 
-       let c = String.get str1 i in
+       let c = Bytes.get str1 i in
        if c <> '\\' then begin
           Bytes.set str1 copyto c; loop (copyto + 1) (i + 1)
        end else begin
           Bytes.set str1 copyto '/';
-          if i < l - 2 && String.get str1 (i + 1) = '\\' then
+          if i < l - 2 && Bytes.get str1 (i + 1) = '\\' then
               loop (copyto + 1) (i + 2)
           else 
               loop (copyto + 1) (i + 1)
        end
   in
-  loop 0 0
+  Bytes.to_string (loop 0 0)
 
 let readingFromStdin = ref false
 

--- a/src/ocamlutil/inthash.ml
+++ b/src/ocamlutil/inthash.ml
@@ -34,7 +34,7 @@ let resize tbl =
   let osize = Array.length odata in
   let nsize = min (2 * osize + 1) Sys.max_array_length in
   if nsize <> osize then begin
-    let ndata = Array.create nsize Empty in
+    let ndata = Array.make nsize Empty in
     let rec insert_bucket = function
         Empty -> ()
       | Cons(key, data, rest) ->

--- a/src/ocamlutil/longarray.ml
+++ b/src/ocamlutil/longarray.ml
@@ -24,7 +24,7 @@ let split_idx (idx: int) : int option =
 
 let rec create (len: int) (init: 'a) : 'a t =
   let len1, len2 = split_len len in
-  (Array.create len1 init) :: (if len2 > 0 then create len2 init else [])
+  (Array.make len1 init) :: (if len2 > 0 then create len2 init else [])
 
 let rec init (len: int) (fn: int -> 'a) : 'a t =
   let len1, len2 = split_len len in

--- a/src/ocamlutil/pretty.ml
+++ b/src/ocamlutil/pretty.ml
@@ -726,7 +726,7 @@ let gprintf (finish : doc -> 'b)
 			   ^ (String.sub format i (j-i+1)));
 	    let j' = succ j in (* eat the d,i,x etc. *)
 	    let format_spec = "% " in
-	    String.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
+	    Bytes.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
             Obj.magic(fun n ->
               collect (dctext1 acc
                          (Int64.format format_spec n))
@@ -736,7 +736,7 @@ let gprintf (finish : doc -> 'b)
 					    ^ (String.sub format i (j-i+1)));
 	    let j' = succ j in (* eat the d,i,x etc. *)
 	    let format_spec = "% " in
-	    String.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
+	    Bytes.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
             Obj.magic(fun n ->
               collect (dctext1 acc
                          (Int32.format format_spec n))
@@ -746,7 +746,7 @@ let gprintf (finish : doc -> 'b)
 					    ^ (String.sub format i (j-i+1)));
 	    let j' = succ j in (* eat the d,i,x etc. *)
 	    let format_spec = "% " in
-	    String.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
+	    Bytes.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
             Obj.magic(fun n ->
               collect (dctext1 acc
                          (Nativeint.format format_spec n))

--- a/src/ocamlutil/pretty.ml
+++ b/src/ocamlutil/pretty.ml
@@ -725,31 +725,31 @@ let gprintf (finish : doc -> 'b)
               invalid_arg ("dprintf: unimplemented format " 
 			   ^ (String.sub format i (j-i+1)));
 	    let j' = succ j in (* eat the d,i,x etc. *)
-	    let format_spec = "% " in
+	    let format_spec = Bytes.of_string "% " in
 	    Bytes.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
             Obj.magic(fun n ->
               collect (dctext1 acc
-                         (Int64.format format_spec n))
+                         (Int64.format (Bytes.to_string format_spec) n))
                 (succ j'))
 	| 'l' ->
 	    if j != i + 1 then invalid_arg ("dprintf: unimplemented format " 
 					    ^ (String.sub format i (j-i+1)));
 	    let j' = succ j in (* eat the d,i,x etc. *)
-	    let format_spec = "% " in
+	    let format_spec = Bytes.of_string "% " in
 	    Bytes.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
             Obj.magic(fun n ->
               collect (dctext1 acc
-                         (Int32.format format_spec n))
+                         (Int32.format (Bytes.to_string format_spec) n))
                 (succ j'))
 	| 'n' ->
 	    if j != i + 1 then invalid_arg ("dprintf: unimplemented format " 
 					    ^ (String.sub format i (j-i+1)));
 	    let j' = succ j in (* eat the d,i,x etc. *)
-	    let format_spec = "% " in
+	    let format_spec = Bytes.of_string "% " in
 	    Bytes.set format_spec 1 (fget j'); (* format_spec = "%x", etc. *)
             Obj.magic(fun n ->
               collect (dctext1 acc
-                         (Nativeint.format format_spec n))
+                         (Nativeint.format (Bytes.to_string format_spec) n))
                 (succ j'))
         | 'f' | 'e' | 'E' | 'g' | 'G' ->
             Obj.magic(fun f ->


### PR DESCRIPTION
OCaml 4.06.0 pulls the Num module out of stdlib into its own separate project.  Nominally it's possible to maintain backwards compatibility by simply installing the now-separate Num (opam!) and presumably tweaking package info to pull in the now-external dependency. But as far as I can tell, it's totally impossible to do this on a machine that's ever had any previous version of ocaml installed.  It may not be possible to do it on a fresh install, either; I wouldn't know.  

tl;dr: ocamlfind couldn't find the new Num. There seems to be a solution involving pinning ocamlfind back to some previous version (see: https://github.com/BinaryAnalysisPlatform/bap/issues/742), but that didn't work for me.

So.  The recommendation is to use ZArith instead of Num anyway.  Zarith is apparently a better, faster implementation of arbitrary-precision integers/rationals (https://github.com/ocaml/Zarith).  Since building CIL with 4.06 involve adding an external dependency (to either Num or Zarith) and Num was giving me nightmares, I thought I'd try my hand at just replacing Num with Zarith and updating Cilint accordingly. 

(TBH the rationale for continuing to wrap what-used-to-be-Bigint in Cilint isn't obvious to me, but that was a bigger refactor than I was willing to make without confirmation/blessing from the project owners/maintainers.)

Confirmed to build on 4.06+trunk, on Darwin and some arbitrary Ubuntu flavor (don't remember which one, I can check if you care), passes no fewer tests after than before.  

Tricky bits:

- 4.06 enforces some deprecation that previously only resulted in a warning, so this PR includes commits that address deprecation warnings that I included in (https://github.com/cil-project/cil/pull/40)
- I don't know how far back in the OCaml release history this will work.  I was thinking that, in your shoes, I'd have a separate dev branch for experimental 4.06 support.  But, since you don't have one, I just issue my PR and leave it to you. 